### PR TITLE
Fixed slides link changing lesson-plans to lesson-plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You will be better equipped to work through this lesson if you have experience i
 
 ## Slides
 
-*   [Slides](https://wptrainingteam.github.io/lesson-plans/introduction-to-css/slides/)
+*   [Slides](https://wptrainingteam.github.io/lesson-plan/introduction-to-css/slides/)
 
 ## Materials Needed
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modified a link to the slides in the README file, removing the "s" from "lesson-plans" in the URL

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your contribution introduce? Put an `x` in all the boxes that apply: -->

- [x] Corrects spelling, formatting, and other style issues
- [ ] Updates the content of the lesson plan
- [ ] Adds content to the lesson plan (initial draft)
- [ ] Brings the lesson plan into conformance with the repo-template (including folders, files, and/or lesson plan format).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My contribution follows the style of this project. (See https://make.wordpress.org/training/handbook/guidelines/lesson-plan-style-guide/).
- [ ] If providing slides, my contribution follows the slide style for this project. (See https://make.wordpress.org/training/handbook/guidelines/slides-style-guide/).
- [ ] The lesson plan follows the current template (See https://github.com/wptrainingteam/repo-template).
- [ ] I have completed the **Team Onboarding (https://make.wordpress.org/training/handbook/getting-started/team-on-boarding/)** tasks.
